### PR TITLE
properly check for request response code

### DIFF
--- a/lib/yoast-vat-updater.php
+++ b/lib/yoast-vat-updater.php
@@ -121,7 +121,7 @@ class Yoast_VAT_Updater {
 	 */
 	private function retrieve_vat_rates() {
 		$resp = wp_remote_get( 'http://jsonvat.com/' );
-		if ( 200 === $resp['response']['code'] ) {
+		if ( 200 === wp_remote_retrieve_response_code( $resp ) ) {
 			$json 		 = wp_remote_retrieve_body( $resp );
 			$vat_details = json_decode( $json );
 


### PR DESCRIPTION
The request response code is currently checked by accessing the array directly. This can cause a problem when the return value is a `WP_Error` object. Plus WordPress provides a function `wp_remote_retrieve_response_code()` to take care of it entirely, so this PR makes use of the function.